### PR TITLE
Fix the html link in README

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ Firing Range is a test bed for web application security scanners,
 providing synthetic, wide coverage for an array of vulnerabilities.
 
 It can be deployed as a Google App Engine application. A public instance is
-is running at [http://public-firing-range.appspot.com](http://public-firing-range.appspot.com).
+is running at http://public-firing-range.appspot.com.
 
 
 # License information


### PR DESCRIPTION
Currently the link goes to a page showing an error:
http://public-firing-range.appspot.com/%5D(http://public-firing-range.appspot.com/)

Error: Not Found

The requested URL /%5D(http://public-firing-range.appspot.com/) was not found on this server.
