### PR TITLE
Add build configuration for lgtm.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,7 @@
+extraction:
+  java:
+    before_index:
+      - wget -q https://storage.googleapis.com/appengine-sdks/featured/appengine-java-sdk-1.9.59.zip -O "${LGTM_WORKSPACE}/sdk.zip"
+      - unzip -q -d "${LGTM_WORKSPACE}" "${LGTM_WORKSPACE}/sdk.zip"
+    index:
+      build_command: ant -Dappengine.sdk="${LGTM_WORKSPACE}/appengine-java-sdk-1.9.59" -noinput


### PR DESCRIPTION
This pull request adds an `.lgtm.yml` configuration file to teach lgtm.com to build this repository.

See also: https://discuss.lgtm.com/t/cannot-build-ant-build-logs-unhelpful/736/2
@paradoxengine 